### PR TITLE
Add Health Check endpoints

### DIFF
--- a/Alloy.Api/Alloy.Api.csproj
+++ b/Alloy.Api/Alloy.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
@@ -30,6 +31,9 @@
     <PackageReference Include="Player.Api.Client" Version="1.6.0" />
     <PackageReference Include="steamfitter.api.client" Version="1.5.1" />
     <PackageReference Include="caster.api.client" Version="1.3.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.1.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Alloy.Api/Controllers/HealthCheckController.cs
+++ b/Alloy.Api/Controllers/HealthCheckController.cs
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Alloy.Api.ViewModels;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Alloy.Api.Controllers
+{
+    public class HealthController : BaseController
+    {
+        private readonly HostedServiceHealthCheck _hostedHealthCheckService;
+        private readonly StartupHealthCheck _startupHealthCheckService;
+        public HealthController(HostedServiceHealthCheck hostedHealthCheckService,
+            StartupHealthCheck startupHealthCheckService)
+        {
+            _hostedHealthCheckService = hostedHealthCheckService;
+            _startupHealthCheckService = startupHealthCheckService;
+        }
+        
+        /// <summary>
+        /// Checks the liveliness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the liveliness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("liveliness")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetLiveliness")]
+        public async Task<IActionResult> GetLiveliness(CancellationToken ct)
+        {
+            var report = await _hostedHealthCheckService.CheckHealthAsync(null,ct);
+
+            return report.Status == HealthStatus.Healthy ? Ok(report) : StatusCode((int)HttpStatusCode.ServiceUnavailable, report);
+        }
+
+        /// <summary>
+        /// Checks the readiness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the readiness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("readiness")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetReadiness")]
+        public async Task<IActionResult> GetReadiness(CancellationToken ct)
+        {
+            var report = await _startupHealthCheckService.CheckHealthAsync(null,ct);
+
+            return report.Status == HealthStatus.Healthy ? Ok(report) : StatusCode((int)HttpStatusCode.ServiceUnavailable, report);
+        }
+    }
+}

--- a/Alloy.Api/Infrastructure/ClientOptions.cs
+++ b/Alloy.Api/Infrastructure/ClientOptions.cs
@@ -6,6 +6,7 @@ namespace Alloy.Api.Infrastructure.Options
     public class ClientOptions
     {
         public int BackgroundTimerIntervalSeconds { get; set; }
+        public int BackgroundTimerHealthSeconds { get; set; }
         public int CasterCheckIntervalSeconds { get; set; }
         public int CasterPlanningMaxWaitMinutes { get; set; }
         public int CasterDeployMaxWaitMinutes { get; set; }

--- a/Alloy.Api/Infrastructure/Extensions/DatabaseExtensions.cs
+++ b/Alloy.Api/Infrastructure/Extensions/DatabaseExtensions.cs
@@ -71,7 +71,7 @@ namespace Alloy.Api.Extensions
             return webHost;
         }
 
-        private static string DbProvider(IConfiguration config)
+        public static string DbProvider(IConfiguration config)
         {
             return config.GetValue<string>("Database:Provider", "Sqlite").Trim();
         }

--- a/Alloy.Api/Infrastructure/HealthChecks/HostedServiceHealthCheck.cs
+++ b/Alloy.Api/Infrastructure/HealthChecks/HostedServiceHealthCheck.cs
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+public class HostedServiceHealthCheck : IHealthCheck
+{
+    private int _healthAllowance = 90;
+    private DateTime _lastRun = DateTime.Now;
+
+    public int HealthAllowance
+    {
+        get => _healthAllowance;
+        set => _healthAllowance = value;
+    }
+    public DateTime LastRun
+    {
+        get => _lastRun;
+        set => _lastRun = value;
+    }
+    public void CompletedRun()
+    {
+        LastRun = DateTime.Now;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, 
+        CancellationToken cancellationToken = default(CancellationToken))
+    {
+        // give triple the run interval for leniency
+        if ((DateTime.Now - LastRun).TotalSeconds < HealthAllowance)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("The hosted service is responsive."));
+        }
+
+        return Task.FromResult(
+            HealthCheckResult.Unhealthy("The hosted service is not responsive."));
+    }
+}

--- a/Alloy.Api/Infrastructure/HealthChecks/StartupHealthCheck.cs
+++ b/Alloy.Api/Infrastructure/HealthChecks/StartupHealthCheck.cs
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+public class StartupHealthCheck : IHealthCheck
+{
+    private volatile bool _startupTaskCompleted = false;
+    public bool StartupTaskCompleted
+    {
+        get => _startupTaskCompleted;
+        set => _startupTaskCompleted = value;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, 
+        CancellationToken cancellationToken = default(CancellationToken))
+    {
+        if (StartupTaskCompleted)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("The startup task is finished."));
+        }
+
+        return Task.FromResult(
+            HealthCheckResult.Unhealthy("The startup task is still running."));
+    }
+}

--- a/Alloy.Api/Services/AlloyBackgroundService.cs
+++ b/Alloy.Api/Services/AlloyBackgroundService.cs
@@ -32,13 +32,15 @@ namespace Alloy.Api.Services
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IAlloyEventQueue _eventQueue;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly StartupHealthCheck _startupHealthCheck;
 
         public AlloyBackgroundService(
                 ILogger<AlloyBackgroundService> logger,
                 IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions,
                 IServiceScopeFactory scopeFactory,
                 IAlloyEventQueue eventQueue,
-                IHttpClientFactory httpClientFactory
+                IHttpClientFactory httpClientFactory,
+                StartupHealthCheck startupHealthCheck
             )
         {
             _logger = logger;
@@ -46,6 +48,7 @@ namespace Alloy.Api.Services
             _scopeFactory = scopeFactory;
             _eventQueue = eventQueue;
             _httpClientFactory = httpClientFactory;
+            _startupHealthCheck = startupHealthCheck;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
@@ -93,7 +96,8 @@ namespace Alloy.Api.Services
                             }
                         }
                     }
-                    bootstrapComplete = true;
+                    bootstrapComplete = true;                    
+                    _startupHealthCheck.StartupTaskCompleted = true;
                 }
                 catch (System.Exception ex)
                 {

--- a/Alloy.Api/appsettings.json
+++ b/Alloy.Api/appsettings.json
@@ -56,6 +56,7 @@
   },
   "ClientSettings": {
     "BackgroundTimerIntervalSeconds": 60,
+    "BackgroundTimerHealthSeconds": 180,
     "CasterCheckIntervalSeconds": 5,
     "CasterPlanningMaxWaitMinutes": 15,
     "CasterDeployMaxWaitMinutes": 120,


### PR DESCRIPTION
## Feature
- Adds `ready` endpoint for startup health
- Adds `live` endpoint for HostedService health

### Configuration Addition
- Adds **ClientSettings__BackgroundTimerHealthSeconds** appsetting, which defaults to `180`, and is the amount of time, in seconds, that the background timer is allowed to run without checking in before the application is considered `unhealthy`

Internal Ticket:  `CRU-1805`