### PR TITLE
switch from implicit to auth code

### DIFF
--- a/Alloy.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Alloy.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -39,9 +39,10 @@ namespace Alloy.Api.Infrastructure.Extensions
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
                     {
-                        Implicit = new OpenApiOAuthFlow
+                        AuthorizationCode = new OpenApiOAuthFlow
                         {
                             AuthorizationUrl = new Uri(authOptions.AuthorizationUrl),
+                            TokenUrl = new Uri(authOptions.TokenUrl),
                             Scopes = new Dictionary<string, string>()
                             {
                                 {authOptions.AuthorizationScope, "public api access"}

--- a/Alloy.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Alloy.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -12,6 +12,7 @@ namespace Alloy.Api.Options
     {
         public string Authority { get; set; }
         public string AuthorizationUrl { get; set; }
+        public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }

--- a/Alloy.Api/Startup.cs
+++ b/Alloy.Api/Startup.cs
@@ -254,6 +254,7 @@ namespace Alloy.Api
                 c.OAuthClientId(_authOptions.ClientId);
                 c.OAuthClientSecret(_authOptions.ClientSecret);
                 c.OAuthAppName(_authOptions.ClientName);
+                c.OAuthUsePkce();
             });
         }
 

--- a/Alloy.Api/appsettings.json
+++ b/Alloy.Api/appsettings.json
@@ -35,6 +35,7 @@
   "Authorization": {
     "Authority": "http://localhost:5000",
     "AuthorizationUrl": "http://localhost:5000/connect/authorize",
+    "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "player player-vm alloy steamfitter caster-api",
     "ClientId": "alloy.swagger",
     "ClientName": "Alloy Swagger UI",


### PR DESCRIPTION
### Security Fix

Change OAuth2 flow from `Implicit` to `Authorization Code` to follow best practices.

### Breaking Change
Need to add `TokenUrl` to the IdentityServer's `token` endpoint as an appsetting, and update the Client in Identity.

Addresses internal issue `CRU-1842`.