### PR TITLE
add user to Steamfitter Scenario on invite and fixed DateTime formatting

### DIFF
--- a/Alloy.Api/Alloy.Api.csproj
+++ b/Alloy.Api/Alloy.Api.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
     <PackageReference Include="Player.Api.Client" Version="1.6.0" />
-    <PackageReference Include="steamfitter.api.client" Version="1.5.1" />
+    <PackageReference Include="steamfitter.api.client" Version="1.7.0" />
     <PackageReference Include="caster.api.client" Version="1.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.1.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Alloy.Api.Data\Alloy.Api.Data.csproj" />
     <ProjectReference Include="..\Alloy.Api.Migrations.PostgreSQL\Alloy.Api.Migrations.PostgreSQL.csproj" />

--- a/Alloy.Api/Controllers/SteamfitterController.cs
+++ b/Alloy.Api/Controllers/SteamfitterController.cs
@@ -1,20 +1,15 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Alloy.Api.Extensions;
-using Alloy.Api.Infrastructure.Exceptions;
 using Alloy.Api.Services;
-using Alloy.Api.ViewModels;
-using Alloy.Api.Infrastructure.Authorization;
 using Swashbuckle.AspNetCore.Annotations;
-using Steamfitter.Api.Models;
+using Steamfitter.Api.Client;
 
 namespace Alloy.Api.Controllers
 {
@@ -34,7 +29,7 @@ namespace Alloy.Api.Controllers
         /// </summary>
         /// <remarks>
         /// Returns a list of all of the ScenarioTemplates.
-        /// </remarks>       
+        /// </remarks>
         /// <returns></returns>
         [HttpGet("scenarioTemplates")]
         [ProducesResponseType(typeof(IEnumerable<ScenarioTemplate>), (int)HttpStatusCode.OK)]
@@ -48,4 +43,3 @@ namespace Alloy.Api.Controllers
     }
 
 }
-

--- a/Alloy.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Alloy.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Player.Api;
-using Steamfitter.Api;
+using Steamfitter.Api.Client;
 
 namespace Alloy.Api.Infrastructure.Extensions
 {
@@ -147,9 +147,7 @@ namespace Alloy.Api.Infrastructure.Extensions
                 httpClient.BaseAddress = steamfitterUri;
                 httpClient.DefaultRequestHeaders.Add("Authorization", authHeader);
 
-                var apiClient = new SteamfitterApiClient(httpClient, true);
-                apiClient.BaseUri = steamfitterUri;
-
+                var apiClient = new SteamfitterApiClient(httpClient);
                 return apiClient;
             });
         }

--- a/Alloy.Api/Infrastructure/JsonConverters/JsonDateTimeConverter.cs
+++ b/Alloy.Api/Infrastructure/JsonConverters/JsonDateTimeConverter.cs
@@ -1,0 +1,22 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Alloy.Api.Infrastructure.JsonConverters
+{
+    public class JsonDateTimeConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetDateTime();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+        }
+    }
+}

--- a/Alloy.Api/Infrastructure/JsonConverters/JsonIntegerConverter.cs
+++ b/Alloy.Api/Infrastructure/JsonConverters/JsonIntegerConverter.cs
@@ -19,7 +19,7 @@ namespace Alloy.Api.Infrastructure.JsonConverters
             return reader.GetInt32();
         }
 
-        public override void Write( Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.ToString());
         }

--- a/Alloy.Api/Services/AlloyBackgroundService.cs
+++ b/Alloy.Api/Services/AlloyBackgroundService.cs
@@ -8,16 +8,15 @@ using Microsoft.Extensions.Options;
 using Alloy.Api.Data;
 using Alloy.Api.Data.Models;
 using Alloy.Api.Infrastructure.Extensions;
-using Alloy.Api.Infrastructure.Options;
 using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using Caster.Api;
 using IdentityModel.Client;
-using Steamfitter.Api;
 using Player.Api;
+using Steamfitter.Api.Client;
+using Task = System.Threading.Tasks.Task;
 
 namespace Alloy.Api.Services
 {

--- a/Alloy.Api/Services/SteamfitterService.cs
+++ b/Alloy.Api/Services/SteamfitterService.cs
@@ -1,18 +1,14 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Rest;
-using Steamfitter.Api;
-using Steamfitter.Api.Models;
 using Alloy.Api.Extensions;
 using Alloy.Api.Infrastructure.Options;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Steamfitter.Api.Client;
 
 namespace Alloy.Api.Services
 {
@@ -30,7 +26,7 @@ namespace Alloy.Api.Services
         {
             _userId = httpContextAccessor.HttpContext.User.GetId();
             _steamfitterApiClient = steamfitterApiClient;
-        }       
+        }
 
         public async Task<IEnumerable<ScenarioTemplate>> GetScenarioTemplatesAsync(CancellationToken ct)
         {
@@ -44,4 +40,3 @@ namespace Alloy.Api.Services
 
     }
 }
-

--- a/Alloy.Api/Startup.cs
+++ b/Alloy.Api/Startup.cs
@@ -131,6 +131,7 @@ namespace Alloy.Api
             {
                 options.PayloadSerializerOptions.PropertyNameCaseInsensitive = true;
                 options.PayloadSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                options.PayloadSerializerOptions.Converters.Add(new JsonDateTimeConverter());
             });
 
             services.AddMvc(options =>
@@ -138,8 +139,8 @@ namespace Alloy.Api
                 options.Filters.Add(typeof(ValidateModelStateFilter));
                 options.Filters.Add(typeof(JsonExceptionFilter));
 
-          // Require all scopes in authOptions
-          var policyBuilder = new AuthorizationPolicyBuilder().RequireAuthenticatedUser();
+                // Require all scopes in authOptions
+                var policyBuilder = new AuthorizationPolicyBuilder().RequireAuthenticatedUser();
                 Array.ForEach(_authOptions.AuthorizationScope.Split(' '), x => policyBuilder.RequireScope(x));
 
                 var policy = policyBuilder.Build();
@@ -150,6 +151,7 @@ namespace Alloy.Api
                 options.JsonSerializerOptions.Converters.Add(new JsonNullableGuidConverter());
                 options.JsonSerializerOptions.Converters.Add(new JsonIntegerConverter());
                 options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                options.JsonSerializerOptions.Converters.Add(new JsonDateTimeConverter());
 
             })
             .SetCompatibilityVersion(CompatibilityVersion.Latest);
@@ -174,18 +176,18 @@ namespace Alloy.Api
                 {
                     OnMessageReceived = context =>
               {
-              // If the request is for our hub...
-              var path = context.HttpContext.Request.Path;
-                    var accessToken = context.Request.Query["access_token"];
+                  // If the request is for our hub...
+                  var path = context.HttpContext.Request.Path;
+                  var accessToken = context.Request.Query["access_token"];
 
-                    if (!string.IsNullOrEmpty(accessToken) &&
-                            (path.StartsWithSegments("/hubs")))
-                    {
-                  // Read the token out of the query string
-                  context.Token = accessToken;
-                    }
-                    return Task.CompletedTask;
-                }
+                  if (!string.IsNullOrEmpty(accessToken) &&
+                          (path.StartsWithSegments("/hubs")))
+                  {
+                      // Read the token out of the query string
+                      context.Token = accessToken;
+                  }
+                  return Task.CompletedTask;
+              }
                 };
             });
 


### PR DESCRIPTION
- use new Steamfitter ScenarioCloneOptions to avoid multiple api calls and reduce error handling
- add user to Steamfitter Scenario when they accept an Event invite
- added JsonDateTimeConverter so all DateTimes get returned with proper UTC formatting