### PR TITLE
adds support for multiple scope formats from identity providers

### DIFF
--- a/Alloy.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
+++ b/Alloy.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using Alloy.Api.Extensions;
 using Alloy.Api.Services;
 using Microsoft.AspNetCore.Authentication;
 using System.Security.Claims;
@@ -19,7 +20,8 @@ namespace Alloy.Api.Infrastructure.ClaimsTransformers
 
         public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
         {
-            var user = await _claimsService.AddUserClaims(principal, true);
+            var user = principal.NormalizeScopeClaims();
+            user = await _claimsService.AddUserClaims(user, true);
             _claimsService.SetCurrentClaimsPrincipal(user);
             return user;
         }

--- a/Alloy.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Alloy.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace Alloy.Api.Extensions
@@ -12,6 +13,47 @@ namespace Alloy.Api.Extensions
         public static Guid GetId(this ClaimsPrincipal principal)
         {
             return Guid.Parse(principal.FindFirst("sub")?.Value);
+        }
+
+        /// <summary>
+        /// Normalize scope claims to handle array or single string
+        /// </summary>
+        public static ClaimsPrincipal NormalizeScopeClaims(this ClaimsPrincipal principal)
+        {
+            var identities = new List<ClaimsIdentity>();
+
+            foreach (var id in principal.Identities)
+            {
+                var identity = new ClaimsIdentity(id.AuthenticationType, id.NameClaimType, id.RoleClaimType);
+
+                foreach (var claim in id.Claims)
+                {
+                    if (claim.Type == "scope")
+                    {
+                        if (claim.Value.Contains(' '))
+                        {
+                            var scopes = claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                            foreach (var scope in scopes)
+                            {
+                                identity.AddClaim(new Claim("scope", scope, claim.ValueType, claim.Issuer));
+                            }
+                        }
+                        else
+                        {
+                            identity.AddClaim(claim);
+                        }
+                    }
+                    else
+                    {
+                        identity.AddClaim(claim);
+                    }
+                }
+
+                identities.Add(identity);
+            }
+
+            return new ClaimsPrincipal(identities);
         }
     }
 }

--- a/Alloy.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Alloy.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -1,11 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Alloy.Api.Options
 {
     public class AuthorizationOptions
@@ -18,6 +13,8 @@ namespace Alloy.Api.Options
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }
         public bool RequireHttpsMetadata { get; set; }
+        public bool ValidateAudience { get; set; } = true;
+        public string[] ValidAudiences { get; set; }
     }
 }
 

--- a/Alloy.Api/appsettings.json
+++ b/Alloy.Api/appsettings.json
@@ -40,7 +40,9 @@
     "ClientId": "alloy.swagger",
     "ClientName": "Alloy Swagger UI",
     "ClientSecret": "",
-    "RequireHttpsMetadata": false
+    "RequireHttpsMetadata": false,
+    "ValidateAudience": true,
+    "ValidAudiences": [] // Defaults to AuthorizationScope if null or empty
   },
   "ResourceOwnerAuthorization": {
     "Authority": "http://localhost:5000",
@@ -73,10 +75,9 @@
       "steamfitterApi": "http://localhost:4400/"
     }
   },
-  "SeedData": {
-  },
+  "SeedData": {},
   "Files": {
-    "LocalDirectory" : "/tmp/"
+    "LocalDirectory": "/tmp/"
   },
   "Resource": {
     "MaxEventsForBasicUser": 2


### PR DESCRIPTION
- support scope claims as array or single space-delimited string
- adds ValidateAudience and ValidAudiences settings
  - allows for more granular control of token validation settings
  - defaults to previous behavior