### PR TITLE
Updated dockerfile to use chiseled-containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.md
+appsettings.*.json
+**/appsettings.*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     uses: cmu-sei/Crucible-Github-Actions/.github/workflows/docker-build.yaml@docker-v1.0
     with:
       imageName: cmusei/alloy-api
+      additionalTarget: debug
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Default docker image now uses the .NET 8 chiseled container image as a base. This defaults to a non-root user and port 8080 and is a minimal container without a shell, for increased security. If deploying through Helm, update to the latest Helm chart version with this release to support these changes. You may need to adjust NFS file permissions if mounting any NFS volumes.

All release images going forward will default to the non-root chiseled image. There will also be an image of the same tag, with "-debug" appended to it that will have a base of the non-root, standard image with a shell. This can be used for debugging issues, if necessary. If you need to use a root user, change the security context in your deployment infrastructure for this container.