### PR TITLE
added support for default teams in player

### DIFF
--- a/Alloy.Api/Alloy.Api.csproj
+++ b/Alloy.Api/Alloy.Api.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.8.1" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageReference Include="Player.Api.Client" Version="3.4.2" />
+    <PackageReference Include="Player.Api.Client" Version="3.4.3" />
     <PackageReference Include="steamfitter.api.client" Version="1.7.0" />
     <PackageReference Include="caster.api.client" Version="1.4.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />


### PR DESCRIPTION
When launching an Event, if the View to be cloned specified a Default Team, Alloy will add the launching user to that Team. If no Default Team exists, default to the previous behavior.