### PR TITLE
Standardize launchUrl to 'api' for Aspire dashboard

### DIFF
--- a/Alloy.Api/Properties/launchSettings.json
+++ b/Alloy.Api/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Alloy.Api": {
       "commandName": "Project",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "launchUrl": "api",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
Changed launchUrl from 'http://localhost:4402/swagger' to 'api' to ensure consistent URL display in the .NET Aspire dashboard.