### PR TITLE
Update to Crucible.Common.EntityEvents 0.2.0

### DIFF
--- a/Alloy.Api.Data/Alloy.Api.Data.csproj
+++ b/Alloy.Api.Data/Alloy.Api.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Crucible.Common.EntityEvents" Version="0.1.0" />
+    <PackageReference Include="Crucible.Common.EntityEvents" Version="0.2.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>

--- a/Alloy.Api.Data/AlloyContext.cs
+++ b/Alloy.Api.Data/AlloyContext.cs
@@ -13,6 +13,7 @@ using Crucible.Common.EntityEvents.Abstractions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Alloy.Api.Data
 {
@@ -91,14 +92,23 @@ namespace Alloy.Api.Data
             }
         }
 
-        protected override async Task PublishEventsAsync(CancellationToken cancellationToken)
+        public override async Task PublishEventsAsync(IReadOnlyList<IEntityEvent> events, CancellationToken cancellationToken)
         {
-            if (EntityEvents.Count > 0 && ServiceProvider is not null)
+            if (ServiceProvider is not null)
             {
                 var mediator = ServiceProvider.GetRequiredService<IMediator>();
-                foreach (var evt in EntityEvents.Cast<INotification>())
+                var logger = ServiceProvider.GetRequiredService<ILogger<AlloyContext>>();
+
+                foreach (var evt in events.Cast<INotification>())
                 {
-                    await mediator.Publish(evt, cancellationToken);
+                    try
+                    {
+                        await mediator.Publish(evt, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Error publishing entity event {EventType}", evt.GetType().Name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adapt to breaking change in Crucible.Common.EntityEvents:

- PublishEventsAsync now receives events as a parameter instead of reading from this.EntityEvents.
- Adds per-event error isolation with try/catch and ILogger so a single handler failure doesn't block remaining events from being published.