### PR TITLE
Fix token expiration handling in background service API clients

### DIFF
--- a/Alloy.Api/Services/AlloyBackgroundService.cs
+++ b/Alloy.Api/Services/AlloyBackgroundService.cs
@@ -764,14 +764,12 @@ namespace Alloy.Api.Services
 
         private async Task<(PlayerApiClient, TokenResponse)> RefreshClient(PlayerApiClient clientObject, TokenResponse tokenResponse, IServiceProvider serviceProvider, CancellationToken ct)
         {
-            // TODO: check for token expiration also
-            if (clientObject == null || tokenResponse == null)
-            {
-                if (tokenResponse == null)
-                {
-                    tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
-                }
+            // Check if token is null or expired
+            bool tokenExpired = tokenResponse != null && tokenResponse.ExpiresIn <= 60; // Refresh if less than 60 seconds left
 
+            if (clientObject == null || tokenResponse == null || tokenExpired)
+            {
+                tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
                 clientObject = PlayerApiExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.urls.playerApi, tokenResponse);
             }
 
@@ -780,14 +778,12 @@ namespace Alloy.Api.Services
 
         private async Task<(SteamfitterApiClient, TokenResponse)> RefreshClient(SteamfitterApiClient clientObject, TokenResponse tokenResponse, IServiceProvider serviceProvider, CancellationToken ct)
         {
-            // TODO: check for token expiration also
-            if (clientObject == null || tokenResponse == null)
-            {
-                if (tokenResponse == null)
-                {
-                    tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
-                }
+            // Check if token is null or expired
+            bool tokenExpired = tokenResponse != null && tokenResponse.ExpiresIn <= 60; // Refresh if less than 60 seconds left
 
+            if (clientObject == null || tokenResponse == null || tokenExpired)
+            {
+                tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
                 clientObject = SteamfitterApiExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.urls.steamfitterApi, tokenResponse);
             }
 
@@ -796,14 +792,12 @@ namespace Alloy.Api.Services
 
         private async Task<(CasterApiClient, TokenResponse)> RefreshClient(CasterApiClient clientObject, TokenResponse tokenResponse, IServiceProvider serviceProvider, CancellationToken ct)
         {
-            // TODO: check for token expiration also
-            if (clientObject == null || tokenResponse == null)
-            {
-                if (tokenResponse == null)
-                {
-                    tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
-                }
+            // Check if token is null or expired
+            bool tokenExpired = tokenResponse != null && tokenResponse.ExpiresIn <= 60; // Refresh if less than 60 seconds left
 
+            if (clientObject == null || tokenResponse == null || tokenExpired)
+            {
+                tokenResponse = await ApiClientsExtensions.GetToken(serviceProvider);
                 clientObject = CasterApiExtensions.GetCasterApiClient(_httpClientFactory, _clientOptions.CurrentValue.urls.casterApi, tokenResponse);
             }
 


### PR DESCRIPTION
Implement proactive token refresh by checking ExpiresIn property before it reaches zero. Tokens are now refreshed when less than 60 seconds remain, preventing 401 errors from expired tokens.

Changes:
- Add token expiration check to all three RefreshClient methods (PlayerApiClient, SteamfitterApiClient, CasterApiClient)
- Refresh tokens proactively at 60-second threshold
- Simplify logic by removing redundant null check
- Resolve TODOs for token expiration checking

This fixes issues where background service would use expired tokens when calling Caster/Player/Steamfitter APIs, causing repeated 401 errors and failed event processing.