### PR TITLE
Return all event statuses in GetMyEventsAsync

### DIFF
--- a/Alloy.Api/Controllers/EventController.cs
+++ b/Alloy.Api/Controllers/EventController.cs
@@ -40,7 +40,7 @@ namespace Alloy.Api.Controllers
         [HttpGet("events")]
         [ProducesResponseType(typeof(IEnumerable<Event>), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "getEvents")]
-        public async Task<IActionResult> Get(CancellationToken ct)
+        public async Task<IActionResult> Get([FromQuery] bool? includeEnded, [FromQuery] int? days, CancellationToken ct)
         {
             IEnumerable<Event> list = new List<Event>();
             if (await _authorizationService.AuthorizeAsync([SystemPermission.ViewEvents], ct))
@@ -49,7 +49,7 @@ namespace Alloy.Api.Controllers
             }
             else
             {
-                list = await _eventService.GetMyEventsAsync(ct);
+                list = await _eventService.GetMyEventsAsync(includeEnded, days, ct);
             }
 
             // add this user's permissions for each event
@@ -127,9 +127,9 @@ namespace Alloy.Api.Controllers
         [HttpGet("events/mine")]
         [ProducesResponseType(typeof(IEnumerable<Event>), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "GetMyEvents")]
-        public async Task<IActionResult> GetMyEventsAsync(CancellationToken ct)
+        public async Task<IActionResult> GetMyEventsAsync([FromQuery] bool? includeEnded, [FromQuery] int? days, CancellationToken ct)
         {
-            var list = await _eventService.GetMyEventsAsync(ct);
+            var list = await _eventService.GetMyEventsAsync(includeEnded, days, ct);
             // add this user's permissions for each event
             AddPermissions(list);
 

--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -156,7 +156,7 @@ namespace Alloy.Api.Services
         {
             var userId = _user.GetId();
             var items = await _context.EventMemberships
-                .Where(x => x.UserId == userId && (x.Event.Status == EventStatus.Active || x.Event.Status == EventStatus.Paused))
+                .Where(x => x.UserId == userId)
                 .Select(m => m.Event)
                 .ToListAsync();
 

--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -31,7 +31,7 @@ namespace Alloy.Api.Services
         Task<IEnumerable<Event>> GetEventTemplateEventsAsync(Guid eventTemplateId, CancellationToken ct);
         Task<IEnumerable<Event>> GetMyEventTemplateEventsAsync(Guid eventTemplateId, bool includeInvites, CancellationToken ct);
         Task<IEnumerable<Event>> GetMyViewEventsAsync(Guid viewId, CancellationToken ct);
-        Task<IEnumerable<Event>> GetMyEventsAsync(CancellationToken ct);
+        Task<IEnumerable<Event>> GetMyEventsAsync(bool? includeEnded, int? days, CancellationToken ct);
         Task<Event> GetAsync(Guid id, CancellationToken ct);
         Task<Event> CreateAsync(Event eventx, CancellationToken ct);
         Task<Event> LaunchEventFromEventTemplateAsync(Guid eventTemplateId, Guid? userId, string username, List<Guid> additionalUserIds, CancellationToken ct);
@@ -152,13 +152,32 @@ namespace Alloy.Api.Services
             return _mapper.Map<IEnumerable<Event>>(items);
         }
 
-        public async Task<IEnumerable<Event>> GetMyEventsAsync(CancellationToken ct)
+        public async Task<IEnumerable<Event>> GetMyEventsAsync(bool? includeEnded, int? days, CancellationToken ct)
         {
             var userId = _user.GetId();
-            var items = await _context.EventMemberships
+            var query = _context.EventMemberships
                 .Where(x => x.UserId == userId)
-                .Select(m => m.Event)
-                .ToListAsync();
+                .Select(m => m.Event);
+
+            // Filter by status if specified
+            if (includeEnded == false)
+            {
+                var excludedStatuses = new List<EventStatus> {
+                    EventStatus.Ended,
+                    EventStatus.Failed,
+                    EventStatus.Expired
+                };
+                query = query.Where(e => !excludedStatuses.Contains(e.Status));
+            }
+
+            // Filter by date range if specified
+            if (days.HasValue)
+            {
+                var cutoffDate = DateTime.UtcNow.AddDays(-days.Value);
+                query = query.Where(e => e.DateCreated >= cutoffDate);
+            }
+
+            var items = await query.ToListAsync(ct);
 
             return _mapper.Map<IEnumerable<Event>>(items);
         }


### PR DESCRIPTION
Previously filtered to only Active and Paused events, excluding Planning, Creating, Applying, Ending, Failed, Ended, and Expired. Now returns all events for the user regardless of status, allowing UI to display complete event lifecycle.