### PR TITLE
Add Administrator bypass for event resource limits

### DIFF
--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -353,7 +353,6 @@ namespace Alloy.Api.Services
             // This checks both JWT token roles (if UseRolesFromIdP enabled) and database role
             if (await _alloyAuthorizationService.AuthorizeAsync([Data.SystemPermission.ManageEvents], ct))
             {
-                _logger.LogInformation($"User {userId} has ManageEvents permission, exempt from resource limits.");
                 return true;  // Skip all limit checks for users with manage permissions
             }
 

--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -345,6 +345,18 @@ namespace Alloy.Api.Services
 
         private async Task<bool> ResourcesAreAvailableAsync(Guid eventTemplateId, Guid userId, CancellationToken ct)
         {
+            // Check if user has ManageUsers permission - indicates Administrator role
+            // This checks both JWT token roles (if UseRolesFromIdP enabled) and database role
+            var hasManageUsersPermission = _user.HasClaim(
+                Infrastructure.Authorization.AuthorizationConstants.PermissionClaimType,
+                Data.SystemPermission.ManageUsers.ToString());
+
+            if (hasManageUsersPermission)
+            {
+                _logger.LogInformation($"User {userId} has ManageUsers permission, exempt from resource limits.");
+                return true;  // Skip all limit checks for users with admin permissions
+            }
+
             var resourcesAvailable = true;
             // check to see if this user already has this EventTemplate Implemented
             var notActiveStatuses = new List<EventStatus>() {

--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Alloy.Api.Data;
 using Alloy.Api.Data.Models;
+using Alloy.Api.Infrastructure.Authorization;
 using Alloy.Api.Infrastructure.Extensions;
 using Alloy.Api.Infrastructure.Exceptions;
 using Alloy.Api.Infrastructure.Options;
@@ -51,6 +52,7 @@ namespace Alloy.Api.Services
     {
         private readonly AlloyContext _context;
         private readonly IAuthorizationService _authorizationService;
+        private readonly IAlloyAuthorizationService _alloyAuthorizationService;
         private readonly ClaimsPrincipal _user;
         private readonly IMapper _mapper;
         private readonly ICasterService _casterService;
@@ -69,6 +71,7 @@ namespace Alloy.Api.Services
         public EventService(
             AlloyContext context,
             IAuthorizationService authorizationService,
+            IAlloyAuthorizationService alloyAuthorizationService,
             IPrincipal user,
             IMapper mapper,
             IPlayerService playerService,
@@ -85,6 +88,7 @@ namespace Alloy.Api.Services
         {
             _context = context;
             _authorizationService = authorizationService;
+            _alloyAuthorizationService = alloyAuthorizationService;
             _user = user as ClaimsPrincipal;
             _mapper = mapper;
             _casterService = casterService;
@@ -345,16 +349,12 @@ namespace Alloy.Api.Services
 
         private async Task<bool> ResourcesAreAvailableAsync(Guid eventTemplateId, Guid userId, CancellationToken ct)
         {
-            // Check if user has ManageUsers permission - indicates Administrator role
+            // Check if user has ManageEvents permission to bypass resource limits
             // This checks both JWT token roles (if UseRolesFromIdP enabled) and database role
-            var hasManageUsersPermission = _user.HasClaim(
-                Infrastructure.Authorization.AuthorizationConstants.PermissionClaimType,
-                Data.SystemPermission.ManageUsers.ToString());
-
-            if (hasManageUsersPermission)
+            if (await _alloyAuthorizationService.AuthorizeAsync([Data.SystemPermission.ManageEvents], ct))
             {
-                _logger.LogInformation($"User {userId} has ManageUsers permission, exempt from resource limits.");
-                return true;  // Skip all limit checks for users with admin permissions
+                _logger.LogInformation($"User {userId} has ManageEvents permission, exempt from resource limits.");
+                return true;  // Skip all limit checks for users with manage permissions
             }
 
             var resourcesAvailable = true;


### PR DESCRIPTION
Administrators with ManageUsers permission are now exempt from:
- One active event per template limit
- MaxEventsForBasicUser total active events limit

This enables bulk deployments via Moodle system accounts without hitting concurrency limits. Permission check uses HasClaim to verify both JWT token roles (if UseRolesFromIdP enabled) and database role.