### PR TITLE
Update helm chart action to use client-id

### DIFF
--- a/.github/workflows/update-helm-chart.yml
+++ b/.github/workflows/update-helm-chart.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Helm chart
-        uses: cmu-sei/Crucible-Github-Actions/actions/update-helm-chart@update-helm-chart-v2
+        uses: cmu-sei/Crucible-Github-Actions/actions/update-helm-chart@update-helm-chart-v3
         with:
           app_name: Alloy API
-          github_app_id: ${{ secrets.CRUCIBLE_HELM_UPDATE_APP_ID }}
+          github_app_client_id: ${{ secrets.CRUCIBLE_HELM_UPDATE_CLIENT_ID }}
           github_app_private_key: ${{ secrets.CRUCIBLE_HELM_UPDATE_PRIVATE_KEY }}
           chart_file: charts/alloy/charts/alloy-api/Chart.yaml
           parent_chart_file: charts/alloy/Chart.yaml


### PR DESCRIPTION
Update helm chart action to use client-id instead of the deprecated app-id