### PR TITLE
Set event name and description immediately on creation

### DIFF
--- a/Alloy.Api/Services/AlloyBackgroundService.cs
+++ b/Alloy.Api/Services/AlloyBackgroundService.cs
@@ -257,8 +257,6 @@ namespace Alloy.Api.Services
                                                 {
                                                     // There is no Caster directory, so start the scenario
                                                     var launchDate = DateTime.UtcNow;
-                                                    eventEntity.Name = eventTemplateEntity.Name;
-                                                    eventEntity.Description = eventTemplateEntity.Description;
                                                     eventEntity.LaunchDate = launchDate;
                                                     eventEntity.ExpirationDate = launchDate.AddHours(eventTemplateEntity.DurationHours);
                                                     eventEntity.Status = EventStatus.Applying;
@@ -474,8 +472,6 @@ namespace Alloy.Api.Services
                                                 if (updateTheEntity)
                                                 {
                                                     var launchDate = DateTime.UtcNow;
-                                                    eventEntity.Name = eventTemplateEntity.Name;
-                                                    eventEntity.Description = eventTemplateEntity.Description;
                                                     eventEntity.LaunchDate = launchDate;
                                                     eventEntity.ExpirationDate = launchDate.AddHours(eventTemplateEntity.DurationHours);
                                                     eventEntity.Status = EventStatus.Active;

--- a/Alloy.Api/Services/EventService.cs
+++ b/Alloy.Api/Services/EventService.cs
@@ -327,6 +327,13 @@ namespace Alloy.Api.Services
                 username = _user.Claims.First(c => c.Type.ToLower() == "name").Value;
             }
 
+            // Get event template to set name and description
+            var eventTemplateEntity = await _context.EventTemplates.FindAsync(eventTemplateId);
+            if (eventTemplateEntity == null)
+            {
+                throw new EntityNotFoundException<EventTemplate>($"EventTemplate {eventTemplateId} was not found.");
+            }
+
             var eventEntity = new EventEntity()
             {
                 Id = Guid.NewGuid(),
@@ -334,6 +341,8 @@ namespace Alloy.Api.Services
                 UserId = userId,
                 Username = username,
                 EventTemplateId = eventTemplateId,
+                Name = $"{eventTemplateEntity.Name} - {username}",
+                Description = eventTemplateEntity.Description,
                 Status = EventStatus.Creating,
                 InternalStatus = InternalEventStatus.LaunchQueued
             };


### PR DESCRIPTION
- Events now named {TemplateName} - {Username} at creation time (previously unset)
- Matches pattern used by Steamfitter and Alloy's Player view creation
- Remove duplicate name/description setting in background service